### PR TITLE
Add OAuth authentication with JWT

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,14 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/jwt": "^10.0.0",
+    "@nestjs/passport": "^10.0.0",
     "reflect-metadata": "^0.2.0",
+    "passport": "^0.7.0",
+    "passport-google-oauth20": "^2.0.0",
+    "passport-kakao": "^1.0.1",
+    "passport-naver": "^1.0.1",
+    "passport-jwt": "^4.0.1",
     "rxjs": "^7.8.1"
   },
   "devDependencies": {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { AuthModule } from './auth/auth.module';
 
 @Module({
-  imports: [],
+  imports: [AuthModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,0 +1,53 @@
+import { Controller, Get, Req, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { AuthService } from './auth.service';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Get('google')
+  @UseGuards(AuthGuard('google'))
+  async googleAuth() {}
+
+  @Get('google/redirect')
+  @UseGuards(AuthGuard('google'))
+  async googleAuthRedirect(@Req() req) {
+    const user = this.authService.validateOAuthLogin(
+      'google',
+      req.user.providerId,
+      req.user.email,
+    );
+    return this.authService.generateTokens(user);
+  }
+
+  @Get('kakao')
+  @UseGuards(AuthGuard('kakao'))
+  async kakaoAuth() {}
+
+  @Get('kakao/redirect')
+  @UseGuards(AuthGuard('kakao'))
+  async kakaoAuthRedirect(@Req() req) {
+    const user = this.authService.validateOAuthLogin(
+      'kakao',
+      req.user.providerId,
+      req.user.email,
+    );
+    return this.authService.generateTokens(user);
+  }
+
+  @Get('naver')
+  @UseGuards(AuthGuard('naver'))
+  async naverAuth() {}
+
+  @Get('naver/redirect')
+  @UseGuards(AuthGuard('naver'))
+  async naverAuthRedirect(@Req() req) {
+    const user = this.authService.validateOAuthLogin(
+      'naver',
+      req.user.providerId,
+      req.user.email,
+    );
+    return this.authService.generateTokens(user);
+  }
+}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { AuthService } from './auth.service';
+import { AuthController } from './auth.controller';
+import { GoogleStrategy } from './strategies/google.strategy';
+import { KakaoStrategy } from './strategies/kakao.strategy';
+import { NaverStrategy } from './strategies/naver.strategy';
+import { JwtStrategy } from './strategies/jwt.strategy';
+
+@Module({
+  imports: [
+    PassportModule,
+    JwtModule.register({
+      secret: 'secret',
+      signOptions: { expiresIn: '1h' },
+    }),
+  ],
+  providers: [AuthService, GoogleStrategy, KakaoStrategy, NaverStrategy, JwtStrategy],
+  controllers: [AuthController],
+})
+export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { User } from './user.interface';
+
+@Injectable()
+export class AuthService {
+  private users: User[] = [];
+  private nextId = 1;
+
+  constructor(private readonly jwtService: JwtService) {}
+
+  validateOAuthLogin(
+    provider: 'google' | 'kakao' | 'naver',
+    providerId: string,
+    email?: string,
+  ): User {
+    let user = this.users.find(
+      (u) => u.provider === provider && u.providerId === providerId,
+    );
+    if (!user) {
+      user = { id: this.nextId++, provider, providerId, email };
+      this.users.push(user);
+    }
+    return user;
+  }
+
+  generateTokens(user: User) {
+    const payload = { sub: user.id };
+    const accessToken = this.jwtService.sign(payload, {
+      expiresIn: '1h',
+    });
+    const refreshToken = this.jwtService.sign(payload, {
+      expiresIn: '7d',
+    });
+    return { accessToken, refreshToken };
+  }
+}

--- a/src/auth/strategies/google.strategy.ts
+++ b/src/auth/strategies/google.strategy.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { Strategy, Profile } from 'passport-google-oauth20';
+
+@Injectable()
+export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
+  constructor() {
+    super({
+      clientID: 'GOOGLE_CLIENT_ID',
+      clientSecret: 'GOOGLE_CLIENT_SECRET',
+      callbackURL: '/auth/google/redirect',
+      scope: ['email', 'profile'],
+    });
+  }
+
+  validate(accessToken: string, refreshToken: string, profile: Profile) {
+    return {
+      provider: 'google',
+      providerId: profile.id,
+      email: profile.emails?.[0]?.value,
+    };
+  }
+}

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor() {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      secretOrKey: 'secret',
+    });
+  }
+
+  validate(payload: any) {
+    return { userId: payload.sub };
+  }
+}

--- a/src/auth/strategies/kakao.strategy.ts
+++ b/src/auth/strategies/kakao.strategy.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import KakaoStrategyBase from 'passport-kakao';
+
+@Injectable()
+export class KakaoStrategy extends PassportStrategy(KakaoStrategyBase, 'kakao') {
+  constructor() {
+    super({
+      clientID: 'KAKAO_CLIENT_ID',
+      clientSecret: 'KAKAO_CLIENT_SECRET',
+      callbackURL: '/auth/kakao/redirect',
+    });
+  }
+
+  validate(accessToken: string, refreshToken: string, profile: any) {
+    return {
+      provider: 'kakao',
+      providerId: profile.id,
+      email: profile._json && profile._json.kakao_account?.email,
+    };
+  }
+}

--- a/src/auth/strategies/naver.strategy.ts
+++ b/src/auth/strategies/naver.strategy.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import NaverStrategyBase from 'passport-naver';
+
+@Injectable()
+export class NaverStrategy extends PassportStrategy(NaverStrategyBase, 'naver') {
+  constructor() {
+    super({
+      clientID: 'NAVER_CLIENT_ID',
+      clientSecret: 'NAVER_CLIENT_SECRET',
+      callbackURL: '/auth/naver/redirect',
+    });
+  }
+
+  validate(accessToken: string, refreshToken: string, profile: any) {
+    return {
+      provider: 'naver',
+      providerId: profile.id,
+      email: profile.emails?.[0]?.value,
+    };
+  }
+}

--- a/src/auth/user.interface.ts
+++ b/src/auth/user.interface.ts
@@ -1,0 +1,6 @@
+export interface User {
+  id: number;
+  provider: 'google' | 'kakao' | 'naver';
+  providerId: string;
+  email?: string;
+}


### PR DESCRIPTION
## Summary
- add Google/Kakao/Naver OAuth strategies via passport
- provide JWT-based authentication service
- expose `/auth` routes for OAuth redirects
- wire AuthModule into AppModule
- update dependencies

## Testing
- `pnpm test` *(fails: jest not found)*
- `pnpm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6867790c7d8c83238133ecfaa50986cf